### PR TITLE
Add ARCropolis Compatability

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -14,6 +14,7 @@ const std::string SimpleModDownloader_PATH = "sdmc:/config/SimpleModDownloader/a
 const std::string FORWARDER_PATH = "sdmc:/config/SimpleModDownloader/forwarder.nro";
 
 const std::vector<std::string> langVector ={"de", "en-US", "es", "fr", "gr", "it", "ja", "ko","pt-BR", "ro", "zh-CN", "auto"};
+const std::vector<std::string> arcVector ={"true", "false"};
 
 const std::vector<std::pair<std::string, std::string>> goodGamesName = {
     {"Pokémon Brillant Diamond", "Pokemon Brilliant Diamond and Shining Pearl"},

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -16,6 +16,8 @@ const std::string FORWARDER_PATH = "sdmc:/config/SimpleModDownloader/forwarder.n
 const std::vector<std::string> langVector ={"de", "en-US", "es", "fr", "gr", "it", "ja", "ko","pt-BR", "ro", "zh-CN", "auto"};
 const std::vector<std::string> arcVector ={"true", "false"};
 
+const std::string smash_tid = "01006A800016E000";
+
 const std::vector<std::pair<std::string, std::string>> goodGamesName = {
     {"Pokémon Brillant Diamond", "Pokemon Brilliant Diamond and Shining Pearl"},
     {"Pokémon Shining Pearl", "Pokemon Brilliant Diamond and Shining Pearl"},

--- a/include/extract.hpp
+++ b/include/extract.hpp
@@ -3,7 +3,7 @@
 #include <string>
 
 namespace extract {
-    bool extractEntry(const std::string& zipFile, const std::string& outputDir);
+    bool extractEntry(const std::string& zipFile, const std::string& outputDir, const std::string& tid);
     bool extractZip(const std::string& zipFile, const std::string& outputDir);
     bool extractRar(const std::string& rarFile, const std::string& outputDir);
     bool extract7z(const std::string& zip7File, const std::string& outputDir);

--- a/include/settings_tab.hpp
+++ b/include/settings_tab.hpp
@@ -7,4 +7,5 @@ public:
     SettingsTab();
 private:
     brls::SelectListItem* item;
+    brls::SelectListItem* arcropolisItem;
 };

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -25,4 +25,8 @@ namespace utils {
     bool cp(char *filein, char *fileout);
     std::string getCurrentLang();
     bool isLangAuto();
+    bool useARCropolis();
+    bool fileHasSmashOption();
+    nlohmann::json getSettings();
+    void writeSettings(nlohmann::json settings);
 };

--- a/resources/i18n/en-US/menu.json
+++ b/resources/i18n/en-US/menu.json
@@ -74,7 +74,8 @@
     },
 
     "settings_tab" : {
-        "language" : "Select language"
+        "language" : "Select language",
+        "arc" : "Use ARCropolis for Smash mods"
     },
 
     "crash" : {

--- a/source/extract.cpp
+++ b/source/extract.cpp
@@ -59,7 +59,6 @@ namespace extract {
 
     bool extractEntry(const std::string& archiveFile, const std::string& outputDir, const std::string& tid) {
         chdir("sdmc:/");
-        std::string smash_tid = "01006A800016E000";
         brls::Logger::debug("tid 2: {}",tid);
         struct archive* archive = archive_read_new();
 

--- a/source/extract.cpp
+++ b/source/extract.cpp
@@ -59,7 +59,6 @@ namespace extract {
 
     bool extractEntry(const std::string& archiveFile, const std::string& outputDir, const std::string& tid) {
         chdir("sdmc:/");
-        brls::Logger::debug("tid 2: {}",tid);
         struct archive* archive = archive_read_new();
 
         /*std::string extension = archiveFile.substr(archiveFile.find_last_of(".") + 1);
@@ -152,13 +151,6 @@ namespace extract {
                 }
             } else {
                 // Smash bros mods
-                std::string nameWithoutExtension = "";
-                size_t extensionPos = archiveFile.find_last_of("."); // Find last dot position
-                if (extensionPos != std::string::npos && (archiveFile.substr(extensionPos) == ".zip" || archiveFile.substr(extensionPos) == ".zip")) {
-                    nameWithoutExtension = archiveFile.substr(0, extensionPos); // Extract substring
-                } else {
-                    std::cout << "No .zip or .7z extension found in the filename." << std::endl;
-                }
                 std::string outputFilePath = fmt::format("sdmc:/ultimate/mods/{}",std::string(entryName));
                 std::cout << outputFilePath << std::endl;
                 std::filesystem::path outputPath(outputFilePath);

--- a/source/extract.cpp
+++ b/source/extract.cpp
@@ -5,6 +5,7 @@
 #include "extract.hpp"
 #include "progress_event.hpp"
 #include "main_frame.hpp"
+#include "utils.hpp"
 
 #include <archive.h>
 #include <archive_entry.h>
@@ -56,8 +57,10 @@ namespace extract {
         return totalSize;
     }
 
-    bool extractEntry(const std::string& archiveFile, const std::string& outputDir) {
+    bool extractEntry(const std::string& archiveFile, const std::string& outputDir, const std::string& tid) {
         chdir("sdmc:/");
+        std::string smash_tid = "01006A800016E000";
+        brls::Logger::debug("tid 2: {}",tid);
         struct archive* archive = archive_read_new();
 
         /*std::string extension = archiveFile.substr(archiveFile.find_last_of(".") + 1);
@@ -106,26 +109,69 @@ namespace extract {
             }
             const char* entryName = archive_entry_pathname(entry);
             std::cout << entryName << std::endl;
+            
+            if ((tid != smash_tid) || (utils::useARCropolis() == false)) {
+                if (std::string(entryName).find("romfs/") != std::string::npos || std::string(entryName).find("exefs/") != std::string::npos) {
+                    
+                    std::string outputFilePath;
+                    if (std::string(entryName).find("romfs/") != std::string::npos)
+                        outputFilePath = outputDir + "/" + std::string(entryName).substr(std::string(entryName).find("romfs/") + 6);
+                    else
+                        outputFilePath = outputDir + "/" + std::string(entryName).substr(std::string(entryName).find("exefs/") + 6);
 
-            // Extract the contents of the 'romfs' directory only
-            if (std::string(entryName).find("romfs/") != std::string::npos || std::string(entryName).find("exefs/") != std::string::npos) {
-                
-                std::string outputFilePath;
-                if (std::string(entryName).find("romfs/") != std::string::npos)
-                    outputFilePath = outputDir + "/" + std::string(entryName).substr(std::string(entryName).find("romfs/") + 6);
-                else
-                    outputFilePath = outputDir + "/" + std::string(entryName).substr(std::string(entryName).find("exefs/") + 6);
+                    std::cout << outputFilePath << std::endl;
+                    std::filesystem::path outputPath(outputFilePath);
+                    std::filesystem::create_directories(outputPath.parent_path());
 
+                    if (archive_entry_filetype(entry) == AE_IFDIR) {
+                        ProgressEvent::instance().incrementStep(1);
+                        // Skip directories
+                        continue;
+                    }
+
+
+                    std::ofstream outputFile(outputFilePath, std::ios::binary);
+                    if (!outputFile) {
+                        std::cout << "Failed to create output file: " << outputFilePath << std::endl;
+                        archive_read_free(archive);
+                        std::filesystem::remove(archiveFile);
+                        ProgressEvent::instance().setStep(ProgressEvent::instance().getMax());
+                        return false;
+                    }
+
+                    const size_t bufferSize = 100000;
+                    char buffer[bufferSize];
+                    ssize_t bytesRead;
+                    while ((bytesRead = archive_read_data(archive, buffer, bufferSize)) > 0) {
+                        outputFile.write(buffer, bytesRead);
+                    }
+
+                    outputFile.close();
+
+                    std::cout << "Extracted file: " << outputFilePath << std::endl;
+                    ProgressEvent::instance().incrementStep(1);
+                }
+            } else {
+                // Smash bros mods
+                std::string nameWithoutExtension = "";
+                size_t extensionPos = archiveFile.find_last_of("."); // Find last dot position
+                if (extensionPos != std::string::npos && archiveFile.substr(extensionPos) == ".zip") {
+                    nameWithoutExtension = archiveFile.substr(0, extensionPos); // Extract substring
+                } else {
+                    std::cout << "No .zip extension found in the filename." << std::endl;
+                }
+                std::string outputFilePath = fmt::format("sdmc:/ultimate/mods/{}",std::string(entryName));
                 std::cout << outputFilePath << std::endl;
                 std::filesystem::path outputPath(outputFilePath);
                 std::filesystem::create_directories(outputPath.parent_path());
-
                 if (archive_entry_filetype(entry) == AE_IFDIR) {
+                    // Create the directory
+                    if (!std::filesystem::create_directory(outputPath)) {
+                        std::cout << "Failed to create directory: " << outputFilePath << std::endl;
+                    }
                     ProgressEvent::instance().incrementStep(1);
-                    // Skip directories
                     continue;
                 }
-
 
                 std::ofstream outputFile(outputFilePath, std::ios::binary);
                 if (!outputFile) {

--- a/source/extract.cpp
+++ b/source/extract.cpp
@@ -155,10 +155,10 @@ namespace extract {
                 // Smash bros mods
                 std::string nameWithoutExtension = "";
                 size_t extensionPos = archiveFile.find_last_of("."); // Find last dot position
-                if (extensionPos != std::string::npos && archiveFile.substr(extensionPos) == ".zip") {
+                if (extensionPos != std::string::npos && (archiveFile.substr(extensionPos) == ".zip" || archiveFile.substr(extensionPos) == ".zip")) {
                     nameWithoutExtension = archiveFile.substr(0, extensionPos); // Extract substring
                 } else {
-                    std::cout << "No .zip extension found in the filename." << std::endl;
+                    std::cout << "No .zip or .7z extension found in the filename." << std::endl;
                 }
                 std::string outputFilePath = fmt::format("sdmc:/ultimate/mods/{}",std::string(entryName));
                 std::cout << outputFilePath << std::endl;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -33,7 +33,6 @@ int main() {
 
     //Use debug log level
     brls::Logger::setLogLevel(brls::LogLevel::DEBUG);
-
     brls::Application::pushView(new MainFrame());
 
     while(brls::Application::mainLoop()) {

--- a/source/mods_list.cpp
+++ b/source/mods_list.cpp
@@ -145,7 +145,7 @@ ModsPage::ModsPage(Mod &mod, Game& game, const std::string& search, const int& p
                         std::regex pattern(":");
                         std::string resultat = std::regex_replace(this->currentGame.title, pattern, " -");
 
-                        extract::extractEntry(fmt::format("sdmc:/config/SimpleModDownloader/{}", i.name), fmt::format("sdmc:{}{}/{}/contents/{}/romfs",utils::getModInstallPath(),resultat, this->currentMod.title, this->currentGame.tid));
+                        extract::extractEntry(fmt::format("sdmc:/config/SimpleModDownloader/{}", i.name), fmt::format("sdmc:{}{}/{}/contents/{}/romfs",utils::getModInstallPath(),resultat, this->currentMod.title, this->currentGame.tid), this->currentGame.tid);
                     }));
 
                     stagedFrame->addStage(new ConfirmPage(stagedFrame, "menu/label/extract"_i18n));

--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -484,4 +484,42 @@ namespace utils {
         }
         return false;
     }
+
+    bool fileHasSmashOption() {
+        brls::Logger::debug("fileHasSmashOption");
+        nlohmann::json settings;
+        std::ifstream file("sdmc:/config/SimpleModDownloader/settings.json");
+        file >> settings;
+        file.close();
+        if (settings.contains("use_arcropolis")) {
+            return true;
+        }
+        return false;
+    }
+
+    bool useARCropolis() {
+        nlohmann::json settings;
+        std::ifstream file("sdmc:/config/SimpleModDownloader/settings.json");
+        file >> settings;
+        file.close();
+
+        if (settings.at("use_arcropolis") == "true") {
+            return true;
+        }
+        return false;
+    }
+
+    nlohmann::json getSettings() {
+        nlohmann::json settings;
+        std::ifstream file("sdmc:/config/SimpleModDownloader/settings.json");
+        file >> settings;
+        file.close();
+        return settings;
+    }
+
+    void writeSettings(nlohmann::json settings) {
+        std::ofstream outFile("sdmc:/config/SimpleModDownloader/settings.json");
+        outFile << settings.dump(4);
+        outFile.close();
+    }
 }


### PR DESCRIPTION
This adds support for [ARCropolis](https://github.com/Raytwo/ARCropolis) - a modding framework for Super Smash Bros. Ultimate. The majority of mods for Smash Ultimate on Gamebanana require ARCropolis and shouldn't be placed in `/mods` or `/Atmposphere/contents`. ARCropolis mods also don't follow the `romfs` and `exefs` structure. This pull request adds a setting option to install complete Smash mods to the ARCropolis mod location (`/ultimate/mods`). The setting will also be added to the `settings.json` file if it is not present so the config file doesn't have to be redistributed. And it defaults to off. 