### PR TITLE
accept less than perfect substring when looking up a game with the op…

### DIFF
--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -16,10 +16,13 @@ namespace cfg {
             std::string getAppLanguage();
             void setAppLanguage(const std::string& app_language);
 
+            bool getStrictSearch();
+            void setStringSearch(bool strict);
 
         private:
 
             std::string app_language;
+            bool is_strict;
 
             void loadConfig();
             void parseConfig();

--- a/include/views/settings_tab.hpp
+++ b/include/views/settings_tab.hpp
@@ -10,4 +10,5 @@ public:
 private:
     BRLS_BIND(brls::SelectorCell, language_selector, "language_selector");
     BRLS_BIND(brls::BooleanCell, debug_cell, "debug_cell");
+    BRLS_BIND(brls::BooleanCell, strict_cell, "strict_cell");
 };

--- a/resources/i18n/en-US/menu.json
+++ b/resources/i18n/en-US/menu.json
@@ -85,7 +85,8 @@
 
     "settings_tab" : {
         "language" : "Select language",
-        "debug" : "Debug layer"
+        "debug" : "Debug layer",
+        "strict": "Strict search when looking up games (no false positives)"
     },
 
     "crash" : {

--- a/resources/xml/tabs/settings_tab.xml
+++ b/resources/xml/tabs/settings_tab.xml
@@ -21,11 +21,13 @@
             paddingLeft="@style/brls/sidebar/padding_left">
 
             <brls:SelectorCell
-            id="language_selector"/>
+                id="language_selector"/>
             
             <brls:BooleanCell
                 id="debug_cell"/>
-                
+            
+            <brls:BooleanCell
+                id="strict_cell"/>
 
         </brls:Box>
 

--- a/source/utils/config.cpp
+++ b/source/utils/config.cpp
@@ -61,12 +61,8 @@ namespace cfg {
     }
 
     void Config::parseConfig() {
-        if(config.contains("language")) {
-            app_language = config["language"];
-        } else {
-            app_language = "en-US";
-        }
-
+        app_language = config.contains("language") ? config["language"].get<std::string>() : "en-US";
+        is_strict = config.contains("is_strict") ? config["is_strict"].get<bool>() : false;
     }
 
     std::string Config::getAppLanguage() {
@@ -77,8 +73,16 @@ namespace cfg {
         this->app_language = app_language;
     }
 
+    bool Config::getStrictSearch() {
+        return this->is_strict;
+    }
+    void Config::setStringSearch(bool strict) {
+        this->is_strict = strict;
+    }
+
     void Config::saveConfig() {
         this->config["language"] = app_language;
+        this->config["is_strict"] = is_strict;
 
         std::ofstream file("sdmc:/config/SimpleModDownloader/settings.json");
         file << this->config.dump(4);

--- a/source/views/settings_tab.cpp
+++ b/source/views/settings_tab.cpp
@@ -37,6 +37,11 @@ SettingsTab::SettingsTab() {
             brls::Logger::info("{} the debug layer", value ? "Open" : "Close");
         });
     });
+
+    this->strict_cell->init("menu/settings_tab/strict"_i18n, config.getStrictSearch(), [](bool value){
+        cfg::Config config;
+        config.setStringSearch(value);
+    });
 }
 
 brls::View* SettingsTab::create()


### PR DESCRIPTION
…tion to toggle it on or off

I couldn't find paper mario mods because the console name has a hyphen, and the gamebanana entry doesn't. I've added a new API endpoint, with a toggle to enable it. It uses the default, less strict, website search

old: 
https://gamebanana.com/apiv11/Util/Game/NameMatch?_sName=Paper%20Mario%3A%20The%20Thousand-Year%20Door

new: 
https://gamebanana.com/apiv11/Util/Search/Results?_sModelName=Game&_sOrder=best_match&_sSearchString=Paper%20Mario%3A%20The%20Thousand-Year%20Door%20%28Switch%29

Also if there are multiple results with the old endpoint, it picks the one that has the "Switch" string if applicable, the first result if not. "Switch" is appended search term for the new endpoint since afaik adding it only increases accuracy

You may download a build here: https://github.com/HamletDuFromage/SimpleModDownloader/actions/runs/9228474981/artifacts/1535983471